### PR TITLE
allow multiple classes in shortcut notation

### DIFF
--- a/src/main/kotlin/de/cvguy/kotlin/koreander/parser/Parser.kt
+++ b/src/main/kotlin/de/cvguy/kotlin/koreander/parser/Parser.kt
@@ -268,7 +268,7 @@ class KoreanderParseEngine(
 
         val name = if(elementExpression == null) "div" else expressionCode(elementExpression, true)
         val id = if(elementIdExpression == null) "" else appendAttributeString("id", elementIdExpression)
-        val classes = if(elementClassExpression == null) "" else appendAttributeString("class", elementClassExpression)
+        val classes = if(elementClassExpression == null) "" else appendClassAttributeString(elementClassExpression)
         val attribute = attributes.map { appendAttributeCode(it.first, it.second) }.joinToString("")
 
         val selfClosing = listOf(
@@ -310,6 +310,10 @@ class KoreanderParseEngine(
     private fun appendAttributeString(name: String, value: Token): String {
         val valueExpression = expressionCode(value, true)
         return """ $name="$valueExpression""""
+    }
+
+    private fun appendClassAttributeString(value: Token): String {
+        return appendAttributeString("class", value).replace(".", " ")
     }
 
     private fun appendAttributeCode(name: Token, value: Token): String {

--- a/src/test/resources/syntax/attributes/shortcutclass_bug3.html
+++ b/src/test/resources/syntax/attributes/shortcutclass_bug3.html
@@ -5,6 +5,7 @@
             <span class="test">test span with test class</span>
             <span id="test2">test span with test id</span>
             <span id="test3" class="test">test span with test id and class</span>
+            <span id="test4" class="test another-test">test span with test id and multiple classes</span>
         </div>
     </body>
 </html>

--- a/src/test/resources/syntax/attributes/shortcutclass_bug3.kor
+++ b/src/test/resources/syntax/attributes/shortcutclass_bug3.kor
@@ -5,3 +5,4 @@
             %span.test test span with test class
             %span#test2 test span with test id
             %span#test3.test test span with test id and class
+            %span#test4.test.another-test test span with test id and multiple classes


### PR DESCRIPTION
Many thanks for the swift resolution of #3 
Another idea I was playing with was the ability to shortcut multiple classes. Since periods are illegal characters in CSS class names it should be safe to consider any used are meant as separators rather than part of an actual class name.

Feel free to close this PR if at this point you feel people should just use `%tag class="a b c"` instead, but I think being able to shortcut multiple classes can make the syntax even more elegant. Especially on tags with no other attributes.